### PR TITLE
Update screen locations to allow the BOT to work, No change to screen size (860x720)

### DIFF
--- a/COCBot/GUI/MBR GUI Control Bottom.au3
+++ b/COCBot/GUI/MBR GUI Control Bottom.au3
@@ -26,7 +26,7 @@ Func Initiate()
 		Local $BSy = ($BSsize[0] > $BSsize[1]) ? $BSsize[1] : $BSsize[0]
 ;		$RunState = True
 	    DisposeWindows()
-		If $BSx <> 860 Or $BSy <> 720 Then
+		If $BSx <> $DEFAULT_WIDTH Or $BSy <> $DEFAULT_HEIGHT Then
 			RegWrite($REGISTRY_KEY_DIRECTORY, "FullScreen", "REG_DWORD", "0")
 			RegWrite($REGISTRY_KEY_DIRECTORY, "GuestHeight", "REG_DWORD", $DEFAULT_HEIGHT)
 			RegWrite($REGISTRY_KEY_DIRECTORY, "GuestWidth", "REG_DWORD", $DEFAULT_WIDTH)

--- a/COCBot/functions/Attack/Attack Algorithms/algorithmTH.au3
+++ b/COCBot/functions/Attack/Attack Algorithms/algorithmTH.au3
@@ -117,7 +117,7 @@ Func AttackTHGrid($troopKind, $iNbOfSpots = 1, $iAtEachSpot = 1, $Sleep = Random
 	EndIf
 	;End All Barracks Troops
 
-	SelectDropTroop($THtroop) ;Select Troop to be Droped
+	SelectDropTroop($THtroop) ;Select Troop to be Dropped
 
 	If _Sleep($iDelayAttackTHGrid1) Then Return
 

--- a/COCBot/functions/Attack/GoldElixirChangeEBO.au3
+++ b/COCBot/functions/Attack/GoldElixirChangeEBO.au3
@@ -35,7 +35,7 @@ Func GoldElixirChangeEBO()
 		$Trophies = getTrophyVillageSearch(48, 138)
 	EndIf
 
-	;CALCULATE WITCH TIMER TO USE
+	;CALCULATE WHICH TIMER TO USE
 	Local $iBegin = TimerInit(), $x = $sTimeStopAtk * 1000, $y = $sTimeStopAtk2 * 1000, $z
 	If Number($Gold1) < Number($stxtMinGoldStopAtk2) And Number($Elixir1) < Number($stxtMinElixirStopAtk2) And Number($DarkElixir1) < Number($stxtMinDarkElixirStopAtk2) And $iChkTimeStopAtk2 = 1 Then
 		$z = $y

--- a/COCBot/functions/Config/ScreenCoordinates.au3
+++ b/COCBot/functions/Config/ScreenCoordinates.au3
@@ -2,6 +2,8 @@
 ; Name ..........: Screen Position Variables
 ; Description ...: Global variables for commonly used X|Y positions, screen check color, and tolerance
 ; Syntax ........: $aXXXXX[Y]  : XXXX is name of point or item being checked, Y = 2 for position only, or 4 when color/tolerance value included
+; Syntax ........: $bXXXXX[4]  : XXXX is name of point or item being checked, X_Top_Left, Y_Top_Left, X_Bottom_Right, Y_Bottom_Right
+; Syntax ........: $cXXXXX[4]  : XXXX is name of point or item being checked, X_Top_Left, Y_Top_Left, Width, Lebgth
 ; Author ........: Code Gorilla #1
 ; Modified ......:
 ; Remarks .......: This file is part of MyBot, previously known as ClashGameBot. Copyright 2015
@@ -11,9 +13,9 @@
 ;                                 x    y     color  tolerance
 Global $aIsMain[4]           = [284,  28, 0x41B1CD, 20] ; Main Screen, Builder Left Eye
 Global $aIsMainGrayed[4]     = [284,  28, 0x215B69, 15] ; Main Screen Grayed, Builder Left Eye
-Global $aTopLeftClient[4]    = [  1,   1, 0x000000,  0] ; TopLeftClient: Tolerance not needed
+Global $aTopLeftClient[4]    = [  1,   1, 0x000000,  20] ; TopLeftClient: Tolerance not needed		//changed tolerance from 0 to 20
 Global $aTopMiddleClient[4]  = [475,   1, 0x000000,  0] ; TopMiddleClient: Tolerance not needed
-Global $aTopRightClient[4]   = [850,   1, 0x000000,  0] ; TopRightClient: Tolerance not needed
+Global $aTopRightClient[4]   = [850,   1, 0x000000,  20] ; TopRightClient: Tolerance not needed		//changed tolerance from 0 to 20
 Global $aBottomRightClient[4]= [850, 675, 0x000000,  0] ; BottomRightClient: Tolerance not needed
 Global $aIsInactive[4]       = [457, 300, 0x33B5E5, 10] ; COC message : 'Anyone there?'
 Global $aReloadButton[2]     = [416, 399]               ; Reload Coc Button after Out of Sync
@@ -36,6 +38,8 @@ Global $aArmyCampSize[2]     = [586, 193]               ; Training Window, Overv
 Global $aIsCampNotFull[4] 	 = [149, 150, 0x761714, 20] ; Training Window, Overview screen Red pixel in Exclamation mark with camp is not full
 Global $aIsCampFull[4]  	 = [151, 154, 0xFFFFFF, 10] ; Training Window, Overview screen White pixel in check mark with camp IS full (can not test for Green, as it has trees under it!)
 Global $aBarrackFull[4] 	 = [392, 154, 0xE84D50, 20] ; Training Window, Barracks Screen, Red pixel in Exclamation mark with Barrack is full
+Global $aBarrackTrain[4] 	 = [585, 205, 0xD0D0C0, 20] ; Training Window, Barracks Screen, Gray arrow when Barrack is NOT training  //new in 4.2.4
+Global $aBarrack1Troop[2] 	 = [550, 195] 				; Training Window, Barracks Screen, Red Minus to delete first training troop  //new in 4.2.4
 Global $aBuildersDigits[2]   = [324,  21]               ; Main Screen, Free/Total Builders
 Global $aLanguageCheck1[4]   = [326,   8, 0xF9FAF9, 20] ; Main Screen Test Language for word 'Builders'
 Global $aLanguageCheck2[4]   = [329,   9, 0x060706, 20] ; Main Screen Test Language for word 'Builders'
@@ -103,7 +107,7 @@ Global $TrainWitc[4]        = [ 646, 324, 0x3D3C65,     20] ;  Fix V4.0.1?
 
 Global $TrainLava[4]        = [ 220, 459, 0x4F4F40,     20] ;  Done
 
-Global $NextBtn[4]          = [ 780, 546, 0xD34300,     20] ;  Next Button
+Global $NextBtn[4]          = [ 815, 500, 0xF0AC28,     40] ;  Next Button used to be [ 780, 546, 0xD34300,     20] in 4.2.3
 ; Someone asking troops : Color 0xD0E978 in x = 121
 
 Global $aRequestTroopsAO[6]	= [705, 290, 0xD2EC80, 0x407D06, 0xD8D8D8, 20] ; Button Request Troops in Army Overview  (x,y,can request, request allready made, army full/no clan, toll)
@@ -160,3 +164,10 @@ Global Const $aRtnHomeCheck1[4]      = [ 363, 548, 0x78C11C, 20]
 Global Const $aRtnHomeCheck2[4]      = [ 497, 548, 0x79C326, 20]
 Global Const $aRtnHomeCheck3[4]      = [ 284,  28, 0x41B1CD, 20]
 
+; ===============================================================================================================================
+; Syntax ........: $bXXXXX[4]  : XXXX is name of point or item being checked, X_Top_Left, Y_Top_Left, X_Bottom_Right, Y_Bottom_Right
+Global $bArmyOverviewTroops[4]           = [128, 165, 738, 240] ; Location of troops trained in the army overview window //used to be 140,165,705,220 in ver 4.2.3
+
+; ===============================================================================================================================
+; Syntax ........: $cXXXXX[4]  : XXXX is name of point or item being checked, X_Top_Left, Y_Top_Left, Width, Lebgth
+Global $cArmyOverviewCampSize[4]           = [192, 144, 66, 14] ; Location of troops trained in the army overview window /used to be 212,144,66,14 in ver 4.2.3

--- a/COCBot/functions/Image Search/ImageSearch.au3
+++ b/COCBot/functions/Image Search/ImageSearch.au3
@@ -16,7 +16,8 @@
 ; Example .......: No
 ; ===============================================================================================================================
 Func _ImageSearch($findImage, $resultPosition, ByRef $x, ByRef $y, $Tolerance)
-	Return _ImageSearchArea($findImage, $resultPosition, 0, 0, 840, 720, $x, $y, $Tolerance)
+	;jp Return _ImageSearchArea($findImage, $resultPosition, 0, 0, 840, 720, $x, $y, $Tolerance)
+	Return _ImageSearchArea($findImage, $resultPosition, 0, 0, $DEFAULT_WIDTH, $DEFAULT_HEIGHT, $x, $y, $Tolerance) ;jp
 EndFunc   ;==>_ImageSearch
 ;
 ;

--- a/COCBot/functions/Main Screen/ZoomOut.au3
+++ b/COCBot/functions/Main Screen/ZoomOut.au3
@@ -14,15 +14,21 @@
 ; ===============================================================================================================================
 Func ZoomOut() ;Zooms out
 	Local $result0, $result1, $i = 0
+	Local $Color_Diff_Top_Left, $Color_Diff_Top_Right ;for debug
+
 	_CaptureRegion(0, 0, 860, 2)
-	If _GetPixelColor($aTopLeftClient[0], $aTopLeftClient[1]) <> Hex($aTopLeftClient[2], 6) Or _
-	_GetPixelColor($aTopMiddleClient[0], $aTopMiddleClient[1]) <> Hex($aTopMiddleClient[2], 6) Or _
-	_GetPixelColor($aTopRightClient[0], $aTopRightClient[1]) <> Hex($aTopRightClient[2], 6) 	Then
+
+	$Color_Diff_Top_Left = MaxColorDiff(_GetPixelColor($aTopLeftClient[0], $aTopLeftClient[1]), Hex($aTopLeftClient[2], 6)) ;for debug
+	$Color_Diff_Top_Right = MaxColorDiff(_GetPixelColor($aTopRightClient[0], $aTopRightClient[1]), Hex($aTopRightClient[2], 6)) ;for debug
+
+	If _CheckPixel($aTopLeftClient, $bNoCapturePixel) = False Or _
+		_CheckPixel($aTopRightClient, $bNoCapturePixel) = False Then
 		SetLog("Zooming Out", $COLOR_BLUE)
+		If $debugSetlog = 1 Then SetLog("Color Diff: " & $Color_Diff_Top_Left & " , " & $Color_Diff_Top_Right,$COLOR_PURPLE) ;dor debug
+
 		If _Sleep($iDelayZoomOut1) Then Return
-		While _GetPixelColor($aTopLeftClient[0], $aTopLeftClient[1]) <> Hex($aTopLeftClient[2], 6) And _
-			_GetPixelColor($aTopMiddleClient[0], $aTopMiddleClient[1]) <> Hex($aTopMiddleClient[2], 6) And _
-			_GetPixelColor($aTopRightClient[0], $aTopRightClient[1]) <> Hex($aTopRightClient[2], 6)
+		While _CheckPixel($aTopLeftClient, $bNoCapturePixel) = False Or _
+			_CheckPixel($aTopRightClient, $bNoCapturePixel) = False ;changed and to or
 			If $debugsetlog = 1 Then Setlog("Index = "&$i, $COLOR_PURPLE) ; Index=2X loop count if success, will be increment by 1 if controlsend fail
 			If _Sleep($iDelayZoomOut2) Then Return
 			$Result0 = ControlFocus($Title, "","")
@@ -36,7 +42,14 @@ Func ZoomOut() ;Zooms out
 			If $i > 20 Then
 				If _Sleep($iDelayZoomOut3) Then Return
 			EndIf
-			If $i > 80 Then Return
+
+			If $i > 80 Then
+				$Color_Diff_Top_Left = MaxColorDiff(_GetPixelColor($aTopLeftClient[0], $aTopLeftClient[1]), Hex($aTopLeftClient[2], 6)) ;for debug
+				$Color_Diff_Top_Right = MaxColorDiff(_GetPixelColor($aTopRightClient[0], $aTopRightClient[1]), Hex($aTopRightClient[2], 6)) ;for debug
+				If $debugSetlog = 1 Then SetLog("Max Zoom Out! Color Diff: " & $Color_Diff_Top_Left & " , " & $Color_Diff_Top_Right,$COLOR_PURPLE) ;for debug
+				Return
+			EndIf
+
 			If IsProblemAffect(True) Then  ; added to catch errors during Zoomout
 				Setlog("BS Error window detected", $COLOR_RED)
 				If checkObstacles() = True Then Setlog("Error window cleared, continue Zoom out", $COLOR_BLUE)  ; call to clear normal errors
@@ -46,3 +59,31 @@ Func ZoomOut() ;Zooms out
 		WEnd
 	EndIf
 EndFunc   ;==>ZoomOut
+
+;function for debug
+Func MaxColorDiff($nColor1, $nColor2)
+	Local $Red1, $Red2, $Blue1, $Blue2, $Green1, $Green2, $MaxDiff
+
+	$Red1 = Dec(StringMid(String($nColor1), 1, 2))
+	$Blue1 = Dec(StringMid(String($nColor1), 3, 2))
+	$Green1 = Dec(StringMid(String($nColor1), 5, 2))
+
+	$Red2 = Dec(StringMid(String($nColor2), 1, 2))
+	$Blue2 = Dec(StringMid(String($nColor2), 3, 2))
+	$Green2 = Dec(StringMid(String($nColor2), 5, 2))
+
+	$MaxDiff = Abs($Red1 - $Red2)
+	if $MaxDiff < Abs($Blue1 - $Blue2) then $MaxDiff = Abs($Blue1 - $Blue2)
+	if $MaxDiff < Abs($Green1 - $Green2) then $MaxDiff = Abs($Green1 - $Green2)
+
+	Return $MaxDiff
+EndFunc   ;==>_MaxColorDiff
+
+;old if and loop
+;if _GetPixelColor($aTopLeftClient[0], $aTopLeftClient[1]) <> Hex($aTopLeftClient[2], 6) Or _
+;	_GetPixelColor($aTopMiddleClient[0], $aTopMiddleClient[1]) <> Hex($aTopMiddleClient[2], 6) Or _
+;	_GetPixelColor($aTopRightClient[0], $aTopRightClient[1]) <> Hex($aTopRightClient[2], 6) 	Then
+
+;While _GetPixelColor($aTopLeftClient[0], $aTopLeftClient[1]) <> Hex($aTopLeftClient[2], 6) And _
+;			_GetPixelColor($aTopMiddleClient[0], $aTopMiddleClient[1]) <> Hex($aTopMiddleClient[2], 6) And _
+;			_GetPixelColor($aTopRightClient[0], $aTopRightClient[1]) <> Hex($aTopRightClient[2], 6)

--- a/COCBot/functions/Other/MakeScreenshot.au3
+++ b/COCBot/functions/Other/MakeScreenshot.au3
@@ -16,7 +16,8 @@
 Func MakeScreenshot($TargetDir, $type = "jpg")
 
 	If IsArray(ControlGetPos($Title, "_ctl.Window", "[CLASS:BlueStacksApp; INSTANCE:1]")) Then
-		_CaptureRegionScreenshot(0, 0, 860, 675)
+		;GM _CaptureRegionScreenshot(0, 0, 860, 675)
+		_CaptureRegionScreenshot(0, 0, $DEFAULT_WIDTH, $DEFAULT_HEIGHT-50)
 		Local $hGraphic = _GDIPlus_ImageGetGraphicsContext($hBitmapScreenshot) ; Get graphics content from bitmap image
 		Local $hBrush = _GDIPlus_BrushCreateSolid(0xFF000029) ;create a brush AARRGGBB (using 0x000029 = Dark Blue)
 		If $ichkScreenshotHideName = 1 Then

--- a/COCBot/functions/Pixels/_CaptureRegion.au3
+++ b/COCBot/functions/Pixels/_CaptureRegion.au3
@@ -1,6 +1,6 @@
 ;Saves a screenshot of the window into memory.
 
-Func _CaptureRegion($iLeft = 0, $iTop = 0, $iRight = 860, $iBottom = 720, $ReturnBMP = False)
+Func _CaptureRegion($iLeft = 0, $iTop = 0, $iRight = $DEFAULT_WIDTH, $iBottom = $DEFAULT_HEIGHT, $ReturnBMP = False)
 	_GDIPlus_BitmapDispose($hBitmap)
 	_WinAPI_DeleteObject($hHBitmap)
 
@@ -30,7 +30,7 @@ Func _CaptureRegion($iLeft = 0, $iTop = 0, $iRight = 860, $iBottom = 720, $Retur
 	If $ReturnBMP Then Return $hBitmap
 EndFunc   ;==>_CaptureRegion
 
-Func _CaptureRegion2($iLeft = 0, $iTop = 0, $iRight = 860, $iBottom = 720)
+Func _CaptureRegion2($iLeft = 0, $iTop = 0, $iRight = $DEFAULT_WIDTH, $iBottom = $DEFAULT_HEIGHT)
 	Local $hHBitmap
 
 	If $ichkBackground = 1 Then
@@ -60,7 +60,7 @@ Func _CaptureRegion2($iLeft = 0, $iTop = 0, $iRight = 860, $iBottom = 720)
 EndFunc   ;==>_CaptureRegion2
 
 
-Func _CaptureRegionScreenshot($iLeft = 0, $iTop = 0, $iRight = 860, $iBottom = 720, $ReturnBMP = False)
+Func _CaptureRegionScreenshot($iLeft = 0, $iTop = 0, $iRight = $DEFAULT_WIDTH, $iBottom = $DEFAULT_HEIGHT, $ReturnBMP = False)
 	_GDIPlus_BitmapDispose($hBitmapScreenshot)
 	_WinAPI_DeleteObject($hHBitmapScreenshot)
 

--- a/COCBot/functions/Read Text/getOcr.au3
+++ b/COCBot/functions/Read Text/getOcr.au3
@@ -106,7 +106,7 @@ Func getArmyTroopKind($x_start, $y_start);  -> Gets kind of troop on army camp o
 EndFunc   ;==>getArmyTroopKind
 
 Func getArmyCampCap($x_start, $y_start);  -> Gets army camp capacity --> train.au3
-	Return getOcrAndCapture("coc-army", $x_start, $y_start, 66, 14, True)
+	Return getOcrAndCapture("coc-army", $x_start, $y_start, $cArmyOverviewCampSize[2], $cArmyOverviewCampSize[3], True) ; changed from 66, 14 to global var
 EndFunc   ;==>getArmyCampCap
 
 Func getBarracksTroopQuantity($x_start, $y_start);  -> Gets quantity of troops in training --> train.au3

--- a/COCBot/functions/Search/CheckZoomOut.au3
+++ b/COCBot/functions/Search/CheckZoomOut.au3
@@ -14,13 +14,14 @@
 ; ===============================================================================================================================
 ;
 Func CheckZoomOut()
-					 _CaptureRegion(0, 0, 860, 2)
-					 If _GetPixelColor(1, 1) <> Hex(0x000000, 6) And _GetPixelColor(850, 1) <> Hex(0x000000, 6) Then
-						   SetLog("Not Zoomed Out! Exiting to MainScreen...", $COLOR_RED)
-						   checkMainScreen() ;exit battle screen
-						   $Restart = True
-						   Return False
-						Else
-						   Return True
-						EndIf
+	_CaptureRegion(0, 0, 860, 2)
+	;If _GetPixelColor(1, 1) <> Hex(0x000000, 6) And _GetPixelColor(850, 1) <> Hex(0x000000, 6) Then ;//old line from 4.2.3
+	If _CheckPixel($aTopLeftClient, $bNoCapturePixel) = False And _CheckPixel($aTopRightClient, $bNoCapturePixel) = False Then
+		SetLog("Not Zoomed Out! Exiting to MainScreen...", $COLOR_RED)
+		checkMainScreen() ;exit battle screen
+		$Restart = True
+		Return False
+	Else
+		Return True
+	EndIf
 EndFunc

--- a/COCBot/functions/Village/Laboratory.au3
+++ b/COCBot/functions/Village/Laboratory.au3
@@ -233,13 +233,13 @@ Func LabUpgrade()
 
 EndFunc   ;==>Laboratory
 
-Func DebugRegionSave($sTxtName = "Unknown", $iLeft = 0, $iTop = 0, $iRight = 860, $iBottom = 720)
+Func DebugRegionSave($sTxtName = "Unknown", $iLeft = 0, $iTop = 0, $iRight = $DEFAULT_WIDTH, $iBottom = $DEFAULT_HEIGHT)
 
 	; Debug Code to save images before zapping for later review, time stamped to align with logfile!
 	SetLog("Taking debug snapshot for later review", $COLOR_GREEN) ;Debug purposes only :)
 	Local $Date = @MDAY & "." & @MON & "." & @YEAR
 	Local $Time = @HOUR & "." & @MIN & "." & @SEC
-	If $iLeft <> 0 And $iTop <> 0 And $iRight <> 860 And $iBottom <> 720 Then
+	If $iLeft <> 0 And $iTop <> 0 And $iRight <> $DEFAULT_WIDTH And $iBottom <> $DEFAULT_HEIGHT Then
 		Local $sName = $sTxtName & "_Left_" & $iLeft & "_Top_" & $iTop & "_Right_" & $iRight & "_Bottom_" & $iBottom & "_"
 	Else
 		$sName = $sTxtName

--- a/COCBot/functions/Village/PushBullet.au3
+++ b/COCBot/functions/Village/PushBullet.au3
@@ -335,7 +335,7 @@ Func PushMsg($Message, $Source = "")
 		Case "RequestScreenshot"
 			Local $Date = @YEAR & "-" & @MON & "-" & @MDAY
 			Local $Time = @HOUR & "." & @MIN
-			_CaptureRegion(0, 0, 860, 720)
+			_CaptureRegion(0, 0, $DEFAULT_WIDTH, $DEFAULT_HEIGHT)
 			$hBitmap_Scaled = _GDIPlus_ImageResize($hBitmap, _GDIPlus_ImageGetWidth($hBitmap) / 2, _GDIPlus_ImageGetHeight($hBitmap) / 2) ;resize image
 			Local $Screnshotfilename = "Screenshot_" & $Date & "_" & $Time & ".jpg"
 			_GDIPlus_ImageSaveToFile($hBitmap_Scaled, $dirTemp & $Screnshotfilename)

--- a/COCBot/functions/Village/Train.au3
+++ b/COCBot/functions/Village/Train.au3
@@ -394,9 +394,11 @@ Func Train()
 			If $FirstStart Then
 				If _Sleep($iDelayTrain2) Then Return
 				$icount = 0
-				While Not _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xE8E8DE, 6), 20) ; while not disappears  green arrow
+				;While Not _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xE8E8DE, 6), 20) //old line from 4.2.3
+				While Not _CheckPixel($aBarrackTrain, $bCapturePixel) ; while not disappears  green arrow
 					If Not (IsTrainPage()) Then Return
-					Click(496, 197, 10, 0, "#0273") ; Remove Troops in training
+					;Click(496, 197, 10, 0, "#0273")  //old line from 4.2.3
+					Click($aBarrack1Troop[0], $aBarrack1Troop[1], 10, 0, "#0284") ; Remove Troops in training
 					$icount += 1
 					If $icount = 100 Then ExitLoop
 				WEnd
@@ -456,9 +458,11 @@ Func Train()
 				;CLICK REMOVE TROOPS
 				If _Sleep($iDelayTrain2) Then Return
 				$icount = 0
-				While Not _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xE8E8DE, 6), 20) ; while not disappears  green arrow
+				;While Not _ColorCheck(_GetPixelColor(585, 205, True), Hex(0xD0D0C0, 6), 20) //old line from 4.2.3
+				While Not _CheckPixel($aBarrackTrain, $bCapturePixel) ; while not disappears  green arrow //used to be 565, 205, 0xE8E8DE in 4.2.3
 					If Not (IsTrainPage()) Then Return ;exit if no train page
-					Click(496, 197, 10, 0, "#0284") ; Remove Troops in training
+					;Click(496, 197, 10, 0, "#0273")  //old line from 4.2.3
+					Click($aBarrack1Troop[0], $aBarrack1Troop[1], 10, 0, "#0284") ; Remove Troops in training
 					$icount += 1
 					If $icount = 100 Then ExitLoop
 				WEnd
@@ -580,7 +584,8 @@ Func Train()
 			If $icmbTroopComp <> 8 And $fullarmy = False And $FirstStart = False Then
 
 				; Checks if there is Troops being trained in this barrack
-				If _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) = False Then ;if no green arrow
+				;If _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) = False Then // old line from 4.2.3
+				If _CheckPixel($aBarrackTrain, $bCapturePixel) = True Then ;if no green arrow
 					$BarrackStatus[$brrNum - 1] = False ; No troop is being trained in this barrack
 				Else
 					$BarrackStatus[$brrNum - 1] = True ; Troops are being trained in this barrack
@@ -626,8 +631,10 @@ Func Train()
 							$brrNum += 1
 							If _Sleep($iDelayTrain1) Then Return
 							$icount = 0
-							While _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) ; while green arrow is there, delete
-								Click(496, 197, 5, 0, "#0285") ; Remove Troops in training
+							;While _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) old line from 4.2.3
+							While Not _CheckPixel($aBarrackTrain, $bCapturePixel) ; while green arrow is there, delete
+								;Click(496, 197, 5, 0, "#0285") //old line from 4.2.3
+								Click($aBarrack1Troop[0], $aBarrack1Troop[1], 5, 0, "#0284") ; Remove Troops in training
 								$icount += 1
 								If $icount = 100 Then ExitLoop
 							WEnd
@@ -684,9 +691,11 @@ Func Train()
 			EndIf
 			If $fullarmy Or $FirstStart Then ; Delete Troops That is being trained
 				$icount = 0
-				While Not _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xE8E8DE, 6), 20) ; while not disappears  green arrow
+				;While Not _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xE8E8DE, 6), 20) //old line from 4.2.3
+				While Not _CheckPixel($aBarrackTrain, $bCapturePixel) ; while not disappears  green arrow
 					If Not (IsTrainPage()) Then Return ;exit if no train page
-					Click(496, 197, 10, 0, "#0287") ; Remove Troops in training
+					;Click(496, 197, 10, 0, "#0287") //old line from 4.2.3
+					Click($aBarrack1Troop[0], $aBarrack1Troop[1], 10, 0, "#0284") ; Remove Troops in training
 					$icount += 1
 					If $icount = 100 Then ExitLoop
 				WEnd
@@ -798,7 +807,8 @@ Func Train()
 			If $icmbTroopComp <> 8 And $fullarmy = False And $FirstStart = False Then
 
 				; Checks if there is Troops being trained in this Dark barrack
-				If _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) = False Then ;if no green arrow
+				;If _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) = False Then //old line from 4.2.3
+				If _CheckPixel($aBarrackTrain, $bCapturePixel) = True Then ;if no green arrow
 					$BarrackDarkStatus[$brrDarkNum - 1] = False ; No troop is being trained in this Dark barrack
 				Else
 					$BarrackDarkStatus[$brrDarkNum - 1] = True ; Troops are being trained in this Dark barrack
@@ -825,8 +835,10 @@ Func Train()
 						$i += 1
 						If _Sleep($iDelayTrain1) Then ExitLoop
 						$icount = 0
-						While _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) ; While Green Arrow is there, delete
-							Click(496, 197, 5, 0, "#0288") ; Remove Troops in training
+						;While _ColorCheck(_GetPixelColor(565, 205, True), Hex(0xa8d070, 6), 20) //old line from 4.2.3
+						While Not _CheckPixel($aBarrackTrain, $bCapturePixel) ; While Green Arrow is there, delete
+							;Click(496, 197, 5, 0, "#0288") //old line from 4.2.3
+							Click($aBarrack1Troop[0], $aBarrack1Troop[1], 5, 0, "#0284") ; Remove Troops in training
 							$icount += 1
 							If $icount = 100 Then ExitLoop
 						WEnd

--- a/COCBot/functions/Village/checkArmyCamp.au3
+++ b/COCBot/functions/Village/checkArmyCamp.au3
@@ -31,14 +31,14 @@ Func checkArmyCamp()
 	If _Sleep($iDelaycheckArmyCamp1) Then Return
 
 	$iTried = 0 ; reset loop safety exit counter
-	$sArmyInfo = getArmyCampCap(212, 144) ; OCR read army trained and total
+	$sArmyInfo = getArmyCampCap($cArmyOverviewCampSize[0], $cArmyOverviewCampSize[1]) ; OCR read army trained and total //used to be 212,144 in ver 4.2.3
 	If $debugSetlog = 1 Then Setlog("OCR $sArmyInfo = " & $sArmyInfo, $COLOR_PURPLE)
 
 	While $iTried < 100 ; 30 - 40 sec
 
 		$iTried += 1
 		If _Sleep($iDelaycheckArmyCamp5) Then Return ; Wait 250ms before reading again
-		$sArmyInfo = getArmyCampCap(212, 144) ; OCR read army trained and total
+		$sArmyInfo = getArmyCampCap($cArmyOverviewCampSize[0], $cArmyOverviewCampSize[1]) ; OCR read army trained and total //used to be 212,144 in ver 4.2.3
 		If $debugSetlog = 1 Then Setlog("OCR $sArmyInfo = " & $sArmyInfo, $COLOR_PURPLE)
 		If StringInStr($sArmyInfo, "#", 0, 1) < 2 Then ContinueLoop ; In case the CC donations recieved msg are blocking, need to keep checking numbers till valid
 
@@ -94,7 +94,7 @@ Func checkArmyCamp()
 	EndIf
 
 	_WinAPI_DeleteObject($hBitmapFirst)
-	Local $hBitmapFirst = _CaptureRegion2(140, 165, 705, 220)
+	Local $hBitmapFirst = _CaptureRegion2($bArmyOverviewTroops[0], $bArmyOverviewTroops[1], $bArmyOverviewTroops[2], $bArmyOverviewTroops[3]) ;capture troops trained in the army overview window
 	If $debugSetlog = 1 Then SetLog("$hBitmapFirst made", $COLOR_PURPLE)
 	If _Sleep($iDelaycheckArmyCamp5) Then Return
 	If $debugSetlog = 1 Then SetLog("Calling MBRfunctions.dll/searchIdentifyTroopTrained ", $COLOR_PURPLE)


### PR DESCRIPTION
The bot works (sort of), without changing the screen size.

What was done:
Update screen locations to allow the BOT work
Converted hard coded numbers into consts
Changed logic of zoom out func
fixed length of train troops screen

Known bugs:
On CoC load sometimes it gets stuck on the attack screen
in searching sometimes it doesn't find the next button
in searching finding TH level doesn't work -> this used to be a minor issue in 4.2.3, only now it doesn't read any TH level and not just some.

Work goes on
